### PR TITLE
Add validation to create-profile function

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,21 +1,19 @@
 [project]
-name = "smart-contracts"
-description = ""
+name = 'smart-contracts'
+description = ''
 authors = []
 telemetry = true
-cache_dir = "./.cache"
-
-# [contracts.counter]
-# path = "contracts/counter.clar"
-
+cache_dir = './.cache'
+requirements = []
+[contracts.user-profile]
+path = 'contracts/user-profile.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
-passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+passes = ['check_checker']
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/contracts/user-profile.clar
+++ b/contracts/user-profile.clar
@@ -1,0 +1,13 @@
+;; user-profile.clar
+(define-map users principal { username: (string-ascii 30), bio: (string-utf8 160) })
+
+(define-public (create-profile (username (string-ascii 30)) (bio (string-utf8 160)))
+  (begin
+    (asserts! (is-none (map-get? users tx-sender)) (err u100)) ;; Ensure the user does not already have a profile
+    (asserts! (> (len username) u0) (err u101)) ;; Ensure username is not empty
+    (asserts! (> (len bio) u0) (err u102)) ;; Ensure bio is not empty
+    (ok (map-set users tx-sender { username: username, bio: bio }))
+  ))
+
+(define-read-only (get-profile (user principal))
+  (ok (map-get? users user)))


### PR DESCRIPTION
This PR adds validation checks to the create-profile function in the user-profile.clar contract. It ensures that the user does not already have a profile, and that the username and bio fields are not empty.