### PR TITLE
feat: Add configuration for Stacks network and contract details

### DIFF
--- a/backend/src/config/stacks.ts
+++ b/backend/src/config/stacks.ts
@@ -1,0 +1,18 @@
+// src/config/stacks.ts
+
+import { StacksTestnet, StacksMainnet } from "@stacks/network";
+
+export const NETWORK_TYPE = process.env.NETWORK_TYPE || "testnet";
+export const STACKS_API_URL =
+  process.env.STACKS_API_URL || "https://stacks-node-api.testnet.stacks.co";
+export const CONTRACT_ADDRESS =
+  process.env.CONTRACT_ADDRESS || "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+export const CONTRACT_NAME = process.env.CONTRACT_NAME || "bitstack-core";
+
+export const getNetwork = () => {
+  return NETWORK_TYPE === "mainnet" ? new StacksMainnet() : new StacksTestnet();
+};
+
+export const getNetworkApiUrl = () => {
+  return STACKS_API_URL;
+};


### PR DESCRIPTION
This PR introduces configuration for Stacks network and contract details. It includes functions to determine the network type (Mainnet or Testnet) and to retrieve the Stacks API URL. Default values are set for various environment variables, ensuring proper configuration across different environments.